### PR TITLE
Fix typo in Overview page of website

### DIFF
--- a/website/docs/overview.md
+++ b/website/docs/overview.md
@@ -65,5 +65,4 @@ end
 
 - [Enabling Runtime Checks](runtime.md)
 
-  Learn how to get **more confidence** out of Sorbet by enabling runtime
-  checks.
+  Learn how to get **more confidence** out of Sorbet by enabling runtime checks.

--- a/website/docs/overview.md
+++ b/website/docs/overview.md
@@ -65,5 +65,5 @@ end
 
 - [Enabling Runtime Checks](runtime.md)
 
-  How to how to get **more confidence** out of Sorbet by enabling runtime
+  Learn how to get **more confidence** out of Sorbet by enabling runtime
   checks.


### PR DESCRIPTION
Phrase all bullet points the same way.

### Motivation

Copy wasn't quite right.

### Test plan

See screenshot:

<img width="794" alt="Screenshot 2023-08-21 at 3 33 54 pm" src="https://github.com/matthew-puku/sorbet/assets/47205255/01006636-fd23-4171-827f-b6f0dbe2addd">

